### PR TITLE
Update OpenAI model

### DIFF
--- a/chatgpt.js
+++ b/chatgpt.js
@@ -8,7 +8,7 @@ const openaiInstance = new openai({
 async function makeRequestLogic(userMessage, max_tokens) {
   try {
     const response = await openaiInstance.chat.completions.create({
-      model: "gpt-3.5-turbo",
+      model: "gpt-4o-mini",
       messages: [     {
         "role": "system",
         "content": "You are named Samuee, you are from seville, respond in Spanish, tipical andalusian words, don't swear."


### PR DESCRIPTION
Update OpenAI model.

https://platform.openai.com/docs/models/gpt-4o-mini
> We recommend choosing `gpt-4o-mini` where you would have previously used `gpt-3.5-turbo` as this model is more capable and cheaper.